### PR TITLE
Recovery flow

### DIFF
--- a/email/email.go
+++ b/email/email.go
@@ -1,20 +1,7 @@
 package email
 
 import (
-	"fmt"
-	"runtime"
-
-	"github.com/RagOfJoes/idp/internal"
 	"github.com/RagOfJoes/idp/internal/config"
-)
-
-var (
-	errInvalidTemplate = func(src error, template, to string) error {
-		_, file, line, _ := runtime.Caller(1)
-		return internal.NewServiceInternalError(src, file, line, "Email_InvalidTemplate", fmt.Sprintf("Invalid %s template data provided", template), map[string]interface{}{
-			"Email": to,
-		})
-	}
 )
 
 type client struct {
@@ -26,15 +13,19 @@ type client struct {
 	welcomeID string
 	// Template ID for Verification template
 	verificationID string
+	// Template ID for Recovery template
+	recoveryID string
 }
 
 func New() Client {
 	cfg := config.Get()
 	return &client{
-		appName:        cfg.Name,
-		apiKey:         cfg.SendGrid.APIKey,
+		appName: cfg.Name,
+		apiKey:  cfg.SendGrid.APIKey,
+
 		welcomeID:      cfg.SendGrid.WelcomeTemplateID,
 		verificationID: cfg.SendGrid.VerificationTemplateID,
+		recoveryID:     cfg.SendGrid.RecoveryTemplateID,
 		sender: Email{
 			Name:  cfg.SendGrid.SenderName,
 			Email: cfg.SendGrid.SenderEmail,

--- a/email/recovery.go
+++ b/email/recovery.go
@@ -1,0 +1,71 @@
+package email
+
+import (
+	"encoding/json"
+	"fmt"
+	"runtime"
+
+	"github.com/RagOfJoes/idp/internal"
+	"github.com/RagOfJoes/idp/internal/config"
+	"github.com/RagOfJoes/idp/internal/validate"
+	"github.com/sendgrid/sendgrid-go"
+)
+
+func (c *client) SendRecovery(to []string, recoveryURL string) error {
+	// Check `to` is a valid email and build Email
+	var emails []*Email
+	var validationErr error
+	for _, e := range to {
+		if err := validate.Var(e, "email"); err != nil {
+			_, file, line, _ := runtime.Caller(1)
+			validationErr = internal.NewServiceInternalError(err, file, line, "", fmt.Sprintf("Value, %s, provided for the argument `to` must be a valid email.", to), map[string]interface{}{
+				"Email": to,
+			})
+			break
+		}
+		emails = append(emails, &Email{
+			Email: e,
+		})
+	}
+	if validationErr != nil {
+		return validationErr
+	}
+	// Build payload
+	cfg := config.Get()
+	pay := Payload{
+		From: Email{
+			Name:  cfg.SendGrid.SenderName,
+			Email: cfg.SendGrid.SenderEmail,
+		},
+		TemplateID: cfg.SendGrid.RecoveryTemplateID,
+		Personalizations: []*Personalization{
+			{
+				To: emails,
+				DynamicTemplateData: map[string]interface{}{
+					"ApplicationName": cfg.Name,
+					"RecoveryURL":     recoveryURL,
+				},
+			},
+		},
+	}
+	body, err := json.Marshal(pay)
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		return internal.NewServiceInternalError(err, file, line, "Email_FailedMarshal", "Failed to marshal payload", map[string]interface{}{
+			"Email":   to,
+			"Payload": pay,
+		})
+	}
+	// Make request to SendGrid
+	request := sendgrid.GetRequest(c.apiKey, "/v3/mail/send", c.host)
+	request.Method = "POST"
+	request.Body = body
+	if _, err := sendgrid.API(request); err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		return internal.NewServiceInternalError(err, file, line, "Email_FailedSend", err.Error(), map[string]interface{}{
+			"Email":   to,
+			"Payload": pay,
+		})
+	}
+	return nil
+}

--- a/email/types.go
+++ b/email/types.go
@@ -5,18 +5,10 @@ import "github.com/RagOfJoes/idp/user/identity"
 // Base types
 //
 
-// Template is the custom type that defines valid templates
-type Template string
-
-const (
-	Welcome      Template = "Welcome"
-	Verification Template = "Verification"
-	Recovery     Template = "Recovery"
-)
-
 type Client interface {
 	SendWelcome(to string, user identity.Identity, verificationURL string) error
 	SendVerification(to string, user identity.Identity, verificationURL string) error
+	SendRecovery(to []string, recoveryURL string) error
 }
 
 // A majority of Sendgrid's types

--- a/flow/recovery/recovery.go
+++ b/flow/recovery/recovery.go
@@ -1,0 +1,86 @@
+package recovery
+
+import (
+	"time"
+
+	"github.com/RagOfJoes/idp/internal"
+	"github.com/RagOfJoes/idp/ui/form"
+	"github.com/gofrs/uuid"
+)
+
+type Status string
+
+const (
+	// IdentifierPending occurs when the flow has just been initialized and must now submit an identifier
+	IdentifierPending Status = "Pending"
+	// LinkPending occurs when the link has been sent via email/sms and is waiting to be activated
+	LinkPending Status = "LinkPending"
+	// Success occurs when recovery has completed successfully
+	Success Status = "Success"
+	// Fail occurs when an invalid identifier has been provided
+	Fail Status = "Fail"
+)
+
+type Flow struct {
+	internal.Base
+	// RequestURL defines the url that initiated flow. This can be used to pass any
+	// relevant data from urls path or query. This can also be used to find locate
+	// or security issues.
+	RequestURL string `json:"-" gorm:"not null" validate:"required"`
+	// Status defines the current state of the flow
+	Status Status `json:"status" gorm:"not null" validate:"required"`
+	// FlowID defines the unique identifier that user's will use to access the flow
+	FlowID string `json:"-" gorm:"not null;uniqueIndex" validate:"required"`
+	// ExpiresAt defines the time when this flow will no longer be valid
+	ExpiresAt time.Time `json:"expires_at" gorm:"index;not null" validate:"required"`
+
+	// Form defines additional information required to continue with flow
+	Form *form.Form `json:"form,omitempty" gorm:"type:json;default:null"`
+
+	// IdentityID defines the user that this flow belongs to
+	IdentityID *uuid.UUID `json:"-" gorm:"index" validate:"required_if=Status LinkPending"`
+}
+
+// IdentifierPayload defines the payload required to move to `LinkPending`
+type IdentifierPayload struct {
+	Identifier string `json:"identifier" form:"identifier" binding:"required" validate:"required"`
+}
+
+// SubmitPayload defines the payload required to complete the flow
+type SubmitPayload struct {
+	Password        string `json:"password" form:"password" binding:"required" validate:"required,min=6,max=128"`
+	ConfirmPassword string `json:"confirm_password" form:"confirm_password" binding:"required" validate:"required,eqfield=Password"`
+}
+
+// Repository defines
+type Repository interface {
+	// Create creates a new flow
+	Create(newFlow Flow) (*Flow, error)
+	// Get retrieves a flow via ID
+	Get(id uuid.UUID) (*Flow, error)
+	// GetByFlowID retrieves a flow via FlowID
+	GetByFlowID(flowID string) (*Flow, error)
+	// GetByIdentityID retrieves a flow via identity ID
+	GetByIdentityID(identityID uuid.UUID) (*Flow, error)
+	// Update updates a flow
+	Update(updateFlow Flow) (*Flow, error)
+	// Delete deletes a flow via ID
+	Delete(id uuid.UUID) error
+}
+
+// Service defines
+type Service interface {
+	// New creates a new flow
+	New(requestURL string) (*Flow, error)
+	// Find does exactly that
+	Find(flowID string) (*Flow, error)
+	// SubmitIdentifier requires the `IdentifierPending` status and the `IdentifierPayload` to move the flow to the next step. An email should also be sent to all backup contacts in transport implementation
+	SubmitIdentifier(flow Flow, payload IdentifierPayload) (*Flow, error)
+	// SubmitUpdatePassword completes the flow
+	SubmitUpdatePassword(flow Flow, payload SubmitPayload) (*Flow, error)
+}
+
+// TableName overrides GORM's table name
+func (Flow) TableName() string {
+	return "recoveries"
+}

--- a/flow/recovery/repository/gorm/gorm.go
+++ b/flow/recovery/repository/gorm/gorm.go
@@ -1,0 +1,62 @@
+package gorm
+
+import (
+	"github.com/RagOfJoes/idp/flow/recovery"
+	"github.com/gofrs/uuid"
+	"gorm.io/gorm"
+)
+
+type gormRecoveryRepository struct {
+	DB *gorm.DB
+}
+
+func NewGormRecoveryRepository(d *gorm.DB) recovery.Repository {
+	return &gormRecoveryRepository{DB: d}
+}
+
+func (g *gormRecoveryRepository) Create(newFlow recovery.Flow) (*recovery.Flow, error) {
+	clone := newFlow
+	if err := g.DB.Create(&clone).Error; err != nil {
+		return nil, err
+	}
+	return &clone, nil
+}
+
+func (g *gormRecoveryRepository) Get(id uuid.UUID) (*recovery.Flow, error) {
+	var flow recovery.Flow
+	if err := g.DB.First(&flow, "id = ?", id).Error; err != nil {
+		return nil, err
+	}
+	return &flow, nil
+}
+
+func (g *gormRecoveryRepository) GetByFlowID(flowID string) (*recovery.Flow, error) {
+	var flow recovery.Flow
+	if err := g.DB.First(&flow, "flow_id = ?", flowID).Error; err != nil {
+		return nil, err
+	}
+	return &flow, nil
+}
+
+func (g *gormRecoveryRepository) GetByIdentityID(identityID uuid.UUID) (*recovery.Flow, error) {
+	var flow recovery.Flow
+	if err := g.DB.First(&flow, "identity_id = ?", identityID).Error; err != nil {
+		return nil, err
+	}
+	return &flow, nil
+}
+
+func (g *gormRecoveryRepository) Update(updateFlow recovery.Flow) (*recovery.Flow, error) {
+	clone := updateFlow
+	if err := g.DB.Save(&clone).Error; err != nil {
+		return nil, err
+	}
+	return &clone, nil
+}
+
+func (g *gormRecoveryRepository) Delete(id uuid.UUID) error {
+	if err := g.DB.Where("id = ?", id).Delete(recovery.Flow{}).Error; err != nil {
+		return err
+	}
+	return nil
+}

--- a/flow/recovery/service/form.go
+++ b/flow/recovery/service/form.go
@@ -1,0 +1,56 @@
+package service
+
+import (
+	"github.com/RagOfJoes/idp/ui/form"
+	"github.com/RagOfJoes/idp/ui/node"
+)
+
+// Generate form for
+func generateInitialForm(action string) form.Form {
+	return form.Form{
+		Action: action,
+		Method: "POST",
+		Nodes: node.Nodes{
+			&node.Node{
+				Type:  node.Input,
+				Group: node.Default,
+				Attributes: &node.InputAttribute{
+					Required: true,
+					Type:     "text",
+					Name:     "identifier",
+					Label:    "Identifier",
+				},
+			},
+		},
+	}
+}
+
+// Generate form for recovery
+func generateRecoveryForm(action string) form.Form {
+	return form.Form{
+		Action: action,
+		Method: "POST",
+		Nodes: node.Nodes{
+			&node.Node{
+				Type:  node.Input,
+				Group: node.Default,
+				Attributes: &node.InputAttribute{
+					Required: true,
+					Name:     "password",
+					Type:     "password",
+					Label:    "New Password",
+				},
+			},
+			&node.Node{
+				Type:  node.Input,
+				Group: node.Default,
+				Attributes: &node.InputAttribute{
+					Required: true,
+					Type:     "password",
+					Name:     "confirm_password",
+					Label:    "Confirm New Password",
+				},
+			},
+		},
+	}
+}

--- a/flow/recovery/service/service.go
+++ b/flow/recovery/service/service.go
@@ -1,0 +1,200 @@
+package service
+
+import (
+	"fmt"
+	"log"
+	"runtime"
+	"time"
+
+	"github.com/RagOfJoes/idp/flow/recovery"
+	"github.com/RagOfJoes/idp/internal"
+	"github.com/RagOfJoes/idp/internal/config"
+	"github.com/RagOfJoes/idp/internal/validate"
+	"github.com/RagOfJoes/idp/pkg/nanoid"
+	"github.com/RagOfJoes/idp/user/contact"
+	"github.com/RagOfJoes/idp/user/credential"
+)
+
+var (
+	errInvalidFlowID = func(src error, f string) error {
+		return internal.NewServiceClientError(src, "Recovery_InvalidFlow", "Invalid or expired flow", map[string]interface{}{
+			"FlowID": f,
+		})
+	}
+	errInvalidFlow = func(src error, f recovery.Flow) error {
+		return internal.NewServiceClientError(src, "Recovery_InvalidFlow", "Invalid or expired flow", map[string]interface{}{
+			"Flow": f,
+		})
+	}
+	errInvalidIdentifierPayload = func(src error, f recovery.Flow, p recovery.IdentifierPayload) error {
+		return internal.NewServiceClientError(src, "Recovery_InvalidIdentifierPayload", "Invalid payload provided", map[string]interface{}{
+			"Flow":    f,
+			"Payload": p,
+		})
+	}
+	errInvalidSubmitPayload = func(src error, f recovery.Flow, p recovery.SubmitPayload) error {
+		desc := "Invalid payload provided"
+		if src != nil {
+			desc = src.Error()
+		}
+		return internal.NewServiceClientError(src, "Recovery_InvalidSubmitPayload", desc, map[string]interface{}{
+			"Flow":    f,
+			"Payload": p,
+		})
+	}
+	// Internal Errors
+	errNanoIDGen = func(src error) error {
+		_, file, line, _ := runtime.Caller(1)
+		return internal.NewServiceInternalError(src, file, line, "Recovery_FailedNanoID", "Failed to generate nano id", nil)
+	}
+	errFailedUpdate = func(src error, o recovery.Flow, n recovery.Flow) error {
+		_, file, line, _ := runtime.Caller(1)
+		return internal.NewServiceInternalError(src, file, line, "Recovery_FailedUpdate", "Failed to update flow", map[string]interface{}{
+			"OldFlow": o,
+			"NewFlow": n,
+		})
+	}
+)
+
+type service struct {
+	r   recovery.Repository
+	cs  credential.Service
+	cos contact.Service
+}
+
+func NewRecoveryService(r recovery.Repository, cs credential.Service, cos contact.Service) recovery.Service {
+	return &service{
+		r:   r,
+		cs:  cs,
+		cos: cos,
+	}
+}
+
+func (s *service) New(requestURL string) (*recovery.Flow, error) {
+	flowID, err := nanoid.New()
+	if err != nil {
+		return nil, errNanoIDGen(err)
+	}
+	cfg := config.Get()
+	action := fmt.Sprintf("%s/%s/%s", cfg.Server.URL, cfg.Recovery.URL, flowID)
+	expire := time.Now().Add(cfg.Recovery.Lifetime)
+	form := generateInitialForm(action)
+	flow := recovery.Flow{
+		FlowID:     flowID,
+		ExpiresAt:  expire,
+		RequestURL: requestURL,
+		Status:     recovery.IdentifierPending,
+
+		Form: &form,
+	}
+	newFlow, err := s.r.Create(flow)
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		return nil, internal.NewServiceInternalError(err, file, line, "Recovery_FailedCreate", "Failed to create new recovery flow", map[string]interface{}{
+			"Flow": flow,
+		})
+	}
+	return newFlow, nil
+}
+
+func (s *service) Find(flowID string) (*recovery.Flow, error) {
+	if flowID == "" {
+		return nil, errInvalidFlowID(nil, flowID)
+	}
+	// Try to get Flow
+	flow, err := s.r.GetByFlowID(flowID)
+	// Check for error or empty flow
+	if err != nil || flow == nil {
+		return nil, errInvalidFlowID(err, flowID)
+	}
+	// Check for expired flow or if flow belongs to user
+	if flow.Status == recovery.Fail || flow.ExpiresAt.Before(time.Now()) {
+		return nil, errInvalidFlow(nil, *flow)
+	}
+	return flow, nil
+}
+
+func (s *service) SubmitIdentifier(flow recovery.Flow, payload recovery.IdentifierPayload) (*recovery.Flow, error) {
+	// Validate flow
+	if err := validate.Check(flow); err != nil {
+		return nil, errInvalidFlow(err, flow)
+	}
+	// Validate payload
+	if err := validate.Check(payload); err != nil {
+		return nil, errInvalidIdentifierPayload(err, flow, payload)
+	}
+	// Make sure flow has the proper state
+	if flow.Status != recovery.IdentifierPending {
+		return nil, errInvalidFlow(nil, flow)
+	}
+	credential, err := s.cs.FindPasswordWithIdentifier(payload.Identifier)
+	if err != nil {
+		updateFlow := flow
+		updateFlow.Status = recovery.Fail
+		updateFlow.Form = nil
+		if _, err := s.r.Update(updateFlow); err != nil {
+			// TODO: Capture Error Here
+			log.Print(err)
+		}
+		return nil, internal.NewServiceClientError(err, "Recovery_InvalidIdentifier", "Account with identifier does not exist", map[string]interface{}{
+			"Flow":    flow,
+			"Payload": payload,
+		})
+	}
+	cfg := config.Get()
+	// Update flow
+	updateFlow := flow
+	updateFlow.Status = recovery.LinkPending
+	updateFlow.IdentityID = &credential.IdentityID
+	// Generate new form
+	action := fmt.Sprintf("%s/%s/%s", cfg.Server.URL, cfg.Recovery.URL, flow.FlowID)
+	form := generateRecoveryForm(action)
+	updateFlow.Form = &form
+	// Update FlowID to ensure that the intended user received the recovery request from their preferred out-of-band communication service. IE: email or phone
+	newFlowID, err := nanoid.New()
+	if err != nil {
+		return nil, errFailedUpdate(err, flow, updateFlow)
+	}
+	updateFlow.FlowID = newFlowID
+	updatedFlow, err := s.r.Update(updateFlow)
+	if err != nil {
+		return nil, errFailedUpdate(err, flow, updateFlow)
+	}
+	return updatedFlow, nil
+}
+
+func (s *service) SubmitUpdatePassword(flow recovery.Flow, payload recovery.SubmitPayload) (*recovery.Flow, error) {
+	// Validate flow
+	if err := validate.Check(flow); err != nil {
+		return nil, errInvalidFlow(err, flow)
+	}
+	// Validate payload
+	if err := validate.Check(payload); err != nil {
+		return nil, errInvalidSubmitPayload(err, flow, payload)
+	}
+	// Make sure flow has the proper state
+	if flow.IdentityID == nil || flow.Status != recovery.LinkPending {
+		return nil, errInvalidFlow(nil, flow)
+	}
+	// Update password
+	_, err := s.cs.UpdatePassword(*flow.IdentityID, payload.Password)
+	if err != nil {
+		_, ok := err.(internal.ClientError)
+		if ok {
+			return nil, internal.NewServiceClientError(err, "Recovery_FailedSubmit", err.Error(), map[string]interface{}{
+				"Flow":    flow,
+				"Payload": payload,
+			})
+		}
+		return nil, err
+	}
+	// Update flow
+	updateFlow := flow
+	updateFlow.Form = nil
+	updateFlow.Status = recovery.Success
+	updatedFlow, err := s.r.Update(updateFlow)
+	if err != nil {
+		return nil, errFailedUpdate(err, flow, updateFlow)
+	}
+	return updatedFlow, nil
+}

--- a/flow/recovery/transport/http.go
+++ b/flow/recovery/transport/http.go
@@ -1,0 +1,218 @@
+package transport
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"runtime"
+
+	"github.com/RagOfJoes/idp/email"
+	"github.com/RagOfJoes/idp/flow/recovery"
+	"github.com/RagOfJoes/idp/internal"
+	"github.com/RagOfJoes/idp/internal/config"
+	"github.com/RagOfJoes/idp/transport"
+	"github.com/RagOfJoes/idp/user/contact"
+	"github.com/RagOfJoes/idp/user/identity"
+	"github.com/gin-gonic/gin"
+)
+
+var (
+	errFailedCreate = func(src error) error {
+		return transport.NewHttpClientError(src, http.StatusInternalServerError, "Recovery_FailedCreate", "Failed to create new recovery flow", nil)
+	}
+	errInvalidFlowID = func(src error, f string) error {
+		return transport.NewHttpClientError(src, http.StatusNotFound, "Recovery_InvalidFlow", "Invalid or expired flow", map[string]interface{}{
+			"FlowID": f,
+		})
+	}
+	errInvalidFlow = func(src error, f recovery.Flow) error {
+		return transport.NewHttpClientError(src, http.StatusNotFound, "Recovery_InvalidFlow", "Invalid or expired flow", map[string]interface{}{
+			"Flow": f,
+		})
+	}
+	errInvalidPayload = func(src error, f recovery.Flow) error {
+		return transport.NewHttpClientError(src, http.StatusNotFound, "Recovery_InvalidPayload", "Invalid payload provided", map[string]interface{}{
+			"Flow": f,
+		})
+	}
+)
+
+type Http struct {
+	e  email.Client
+	s  recovery.Service
+	is identity.Service
+}
+
+func NewRecoveryHttp(e email.Client, s recovery.Service, is identity.Service, r *gin.Engine) {
+	cfg := config.Get()
+	h := &Http{
+		e:  e,
+		s:  s,
+		is: is,
+	}
+
+	group := r.Group(fmt.Sprintf("/%s", cfg.Recovery.URL))
+	{
+		group.GET("/", h.initFlow())
+		group.GET("/:flow_id", h.getFlow())
+		group.POST("/:flow_id", h.submitFlow())
+	}
+}
+
+func (h *Http) initFlow() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Check if user is already authenticated
+		if sess := transport.IsAuthenticated(c); sess != nil {
+			c.Error(transport.ErrAlreadyAuthenticated(nil, c.Request.URL.Path, *sess.Identity))
+			return
+		}
+		// Retrieve request URL
+		reqURL := c.Request.URL.Path
+		reqQuery := c.Request.URL.Query().Encode()
+		fullURL := reqURL
+		if len(reqQuery) > 0 {
+			fullURL = fmt.Sprintf("%s?%s", reqURL, reqQuery)
+		}
+		// Create new flow
+		newFlow, err := h.s.New(fullURL)
+		if err != nil {
+			c.Error(transport.GetHttpError(err, errFailedCreate(err), HttpCodeMap))
+			return
+		}
+		c.JSON(http.StatusOK, transport.HttpResponse{
+			Success: true,
+			Payload: newFlow,
+		})
+	}
+}
+
+func (h *Http) getFlow() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Check if user is already authenticated
+		if sess := transport.IsAuthenticated(c); sess != nil {
+			c.Error(transport.ErrAlreadyAuthenticated(nil, c.Request.URL.Path, *sess.Identity))
+			return
+		}
+		// Retrieve FlowID
+		flowID := c.Param("flow_id")
+		// Retrieve Flow
+		flow, err := h.s.Find(flowID)
+		if err != nil {
+			c.Error(transport.GetHttpError(err, errInvalidFlowID(err, flowID), HttpCodeMap))
+			return
+		}
+		c.JSON(http.StatusOK, transport.HttpResponse{
+			Success: true,
+			Payload: flow,
+		})
+	}
+}
+
+func (h *Http) submitFlow() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Check if user is already authenticated
+		if sess := transport.IsAuthenticated(c); sess != nil {
+			c.Error(transport.ErrAlreadyAuthenticated(nil, c.Request.URL.Path, *sess.Identity))
+			return
+		}
+		// Retrieve FlowID
+		flowID := c.Param("flow_id")
+		// Retrieve Flow
+		flow, err := h.s.Find(flowID)
+		if err != nil {
+			c.Error(transport.GetHttpError(err, errInvalidFlowID(err, flowID), HttpCodeMap))
+			return
+		}
+
+		switch flow.Status {
+		case recovery.IdentifierPending:
+			// Make sure user provided proper payload
+			var payload recovery.IdentifierPayload
+			if err := c.ShouldBind(&payload); err != nil {
+				c.Error(errInvalidPayload(err, *flow))
+				return
+			}
+			// Call service
+			submittedFlow, err := h.s.SubmitIdentifier(*flow, payload)
+			if err != nil {
+				clientErr, ok := err.(internal.ClientError)
+				if ok && clientErr.Title() == "Recovery_InvalidIdentifier" {
+					// TODO: Capture Error Here
+					// Return early so that we don't accidentally refer to a nil pointer
+					c.JSON(http.StatusOK, transport.HttpResponse{
+						Success: true,
+						Payload: "Check your email for a link to reset your password. If it doesn’t appear within a few minutes, check your spam folder.",
+					})
+					return
+				}
+				c.Error(transport.GetHttpError(err, transport.NewHttpClientError(err, http.StatusInternalServerError, "Recovery_FailedSubmit", "Failed to submit flow. Please try again later", map[string]interface{}{
+					"Flow":    flow,
+					"Payload": payload,
+				}), HttpCodeMap))
+				return
+			}
+
+			go func(flow recovery.Flow) {
+				if submittedFlow.Status == recovery.LinkPending {
+					var emails []string
+					identity, err := h.is.Find(submittedFlow.IdentityID.String())
+					if err != nil {
+						// TODO: Capture Error Here
+						return
+					}
+
+					if len(identity.Contacts) == 1 {
+						emails = append(emails, identity.Contacts[0].Value)
+					} else {
+						for _, c := range identity.Contacts {
+							if c.Type == contact.Backup && c.Verified && c.State == contact.Completed {
+								emails = append(emails, c.Value)
+							}
+						}
+					}
+					cfg := config.Get()
+					recoveryURL := fmt.Sprintf("%s/%s/%s", cfg.Server.URL, cfg.Recovery.URL, flow.FlowID)
+					if err := h.e.SendRecovery(emails, recoveryURL); err != nil {
+						// TODO: Capture Error Here
+						log.Print(err)
+					}
+				}
+			}(*submittedFlow)
+
+			c.JSON(http.StatusOK, transport.HttpResponse{
+				Success: true,
+				Payload: "Check your email for a link to reset your password. If it doesn’t appear within a few minutes, check your spam folder.",
+			})
+		case recovery.LinkPending:
+			// Make sure user provided proper payload
+			var payload recovery.SubmitPayload
+			if err := c.ShouldBind(&payload); err != nil {
+				c.Error(errInvalidPayload(err, *flow))
+				return
+			}
+			// Call service
+			submittedFlow, err := h.s.SubmitUpdatePassword(*flow, payload)
+			if err != nil {
+				_, ok := err.(internal.ClientError)
+				if ok {
+					c.Error(err)
+					return
+				}
+				_, file, line, _ := runtime.Caller(1)
+				c.Error(transport.GetHttpError(err, transport.NewHttpInternalError(err, file, line, "Recovery_FailedSubmit", "Failed to submit flow. Please try again later", map[string]interface{}{
+					"IdentityID": flow.IdentityID,
+					"Flow":       flow,
+					"Payload":    payload,
+				}), HttpCodeMap))
+				return
+			}
+			c.JSON(http.StatusOK, transport.HttpResponse{
+				Success: true,
+				Payload: submittedFlow,
+			})
+		default:
+			c.Error(errInvalidFlow(err, *flow))
+			return
+		}
+	}
+}

--- a/flow/recovery/transport/http_errors.go
+++ b/flow/recovery/transport/http_errors.go
@@ -1,0 +1,13 @@
+package transport
+
+import (
+	"net/http"
+)
+
+// HttpCodeMap is a map of HTTP status codes that correlate to ServiceClientError's summaries
+var HttpCodeMap = map[string]int{
+	"Recovery_InvalidFlow":              http.StatusNotFound,
+	"Recovery_InvalidSubmitPayload":     http.StatusBadRequest,
+	"Recovery_InvalidIdentifierPayload": http.StatusBadRequest,
+	"Recovery_FailedCreate":             http.StatusInternalServerError,
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ type Configuration struct {
 	//
 
 	Login        Login
+	Recovery     Recovery
 	Registration Registration
 	Verification Verification
 
@@ -62,6 +63,10 @@ func Setup(filename string, filetype string, filepath string) error {
 
 		Login: Login{
 			URL:      "login",
+			Lifetime: time.Minute * 10,
+		},
+		Recovery: Recovery{
+			URL:      "recovery",
 			Lifetime: time.Minute * 10,
 		},
 		Registration: Registration{

--- a/internal/config/flows.go
+++ b/internal/config/flows.go
@@ -16,7 +16,7 @@ type Login struct {
 type Registration struct {
 	// URL for flow
 	//
-	// Default: login
+	// Default: registration
 	URL string
 	// Lifetime of flow
 	//
@@ -27,7 +27,18 @@ type Registration struct {
 type Verification struct {
 	// URL for flow
 	//
-	// Default: login
+	// Default: verification
+	URL string
+	// Lifetime of flow
+	//
+	// Default: 10m
+	Lifetime time.Duration
+}
+
+type Recovery struct {
+	// URL for flow
+	//
+	// Default: recovery
 	URL string
 	// Lifetime of flow
 	//

--- a/internal/config/sendgrid.go
+++ b/internal/config/sendgrid.go
@@ -7,4 +7,5 @@ type SendGrid struct {
 
 	WelcomeTemplateID      string `validate:"required"`
 	VerificationTemplateID string `validate:"required"`
+	RecoveryTemplateID     string `validate:"required"`
 }

--- a/persistence/gorm.go
+++ b/persistence/gorm.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/RagOfJoes/idp/flow/login"
+	"github.com/RagOfJoes/idp/flow/recovery"
 	"github.com/RagOfJoes/idp/flow/registration"
 	"github.com/RagOfJoes/idp/flow/verification"
 	"github.com/RagOfJoes/idp/internal/config"
@@ -74,6 +75,7 @@ func migrate(db *gorm.DB) error {
 		&credential.Credential{},
 
 		&login.Flow{},
+		&recovery.Flow{},
 		&verification.Flow{},
 		&registration.Flow{},
 	)

--- a/user/contact/contact.go
+++ b/user/contact/contact.go
@@ -7,18 +7,26 @@ import (
 	"github.com/gofrs/uuid"
 )
 
+// Type defines the type of contact
 type Type string
-type Method string
+
+const (
+	// Default means that this contact can be used as a valid identifier
+	// pair with a credential to log user in
+	Default Type = "Default"
+	// Backup means that this contact can be used to recover account
+	Backup Type = "Backup"
+)
+
+// State defines the current state of verification for this particular contact
 type State string
 
 const (
-	Default Type = "default"
-	Backup  Type = "backup"
-
-	Email Method = "email"
-
-	Sent      State = "sent"
-	Completed State = "completed"
+	// Sent means the verification link was sent to an out of band communication provider
+	// ie: Email
+	Sent State = "Sent"
+	// Completed means the contact has successfully been verified
+	Completed State = "Completed"
 )
 
 type Contact struct {
@@ -28,24 +36,16 @@ type Contact struct {
 	// VerifiedAt is the verification date
 	VerifiedAt *time.Time `json:"verified_at" gorm:"default:null"`
 
-	// Type is the type of address.
+	// Type defines the type of contact
 	//
 	// Any type besides default will be ignored
-	// if state != "completed" or if verified is false.
-	//
-	// enum{ "default", "backup" }
-	//
-	// "default" means this is just a contact.
-	// "backup" means this address is also a backup so user's
-	// can use it for recovering accounts.
+	// if state != "Complete" or if verified is false.
 	Type Type `json:"type" gorm:"index;not null;default:default"`
-	// Method is the delivery method for verification
-	Method Method `json:"method" gorm:"default:email" validate:"oneof='email'"`
-	// State is the current state of the verification process.
+	// State defines the current state of verification for this particular contact
 	//
-	// "sent" means the verification link, email, sms, etc.
+	// "Sent" means the verification link, email, sms, etc.
 	// was sent.
-	// "completed" means the verification process been fulfilled
+	// "Completed" means the verification process been fulfilled
 	// by the user.
 	State State `json:"state" gorm:"not null" validate:"oneof='sent' 'completed'"`
 	// Value is the actual value to be verified. This can
@@ -73,9 +73,9 @@ type Repository interface {
 }
 
 type Service interface {
-	// Find finds a single contact based on
-	Find(string) (*Contact, error)
+	// Find finds a single contact based on the value provided
+	Find(value string) (*Contact, error)
 	// Add adds a single or a collection of contacts. This should ideally
 	// merge new and old Contact that a user owns
-	Add(...Contact) ([]Contact, error)
+	Add(contacts ...Contact) ([]Contact, error)
 }

--- a/user/credential/credential.go
+++ b/user/credential/credential.go
@@ -54,14 +54,27 @@ type CredentialOIDC struct {
 }
 
 type Repository interface {
-	Create(Credential) (*Credential, error)
-	GetWithIdentifier(CredentialType, string) (*Credential, error)
-	GetWithIdentityID(CredentialType, uuid.UUID) (*Credential, error)
-	Update(Credential) (*Credential, error)
-	Delete(uuid.UUID) error
+	// Create creates a new credential
+	Create(newCredential Credential) (*Credential, error)
+	// GetIdentifier retrieves an identifier
+	GetIdentifier(identifier string) (*Identifier, error)
+	// GetWithIdentifier retrieves a credential with an identifier
+	GetWithIdentifier(credentialType CredentialType, identifier string) (*Credential, error)
+	// GetWithIdentityID retrieves a credential with an identity id
+	GetWithIdentityID(credentialType CredentialType, identityID uuid.UUID) (*Credential, error)
+	// Update updates a credential
+	Update(updateCredential Credential) (*Credential, error)
+	// Delete deletes a credential via id
+	Delete(id uuid.UUID) error
 }
 
 type Service interface {
-	CreatePassword(uid uuid.UUID, password string, identifiers []Identifier) (*Credential, error)
-	ComparePassword(uid uuid.UUID, password string) error
+	// CreatePassword creates a password credential
+	CreatePassword(identityID uuid.UUID, password string, identifiers []Identifier) (*Credential, error)
+	// ComparePassword compares a password credential
+	ComparePassword(identityID uuid.UUID, password string) error
+	// FindPasswordWithIdentifier finds a password with an identifier
+	FindPasswordWithIdentifier(Identifier string) (*Credential, error)
+	// UpdatePassword updates a password credential
+	UpdatePassword(identityID uuid.UUID, newPassword string) (*Credential, error)
 }

--- a/user/credential/service/service.go
+++ b/user/credential/service/service.go
@@ -17,6 +17,39 @@ var (
 			"IdentityID": i,
 		})
 	}
+	errWeakPassword = func(src error, i uuid.UUID, identifiers []credential.Identifier) error {
+		return internal.NewServiceClientError(nil, "Credential_WeakPassword", "Password provided is too weak", map[string]interface{}{
+			"IdentityID":  i,
+			"Identifiers": identifiers,
+		})
+	}
+	errFailedGeneratePassword = func(src error, i uuid.UUID, identifiers []credential.Identifier) error {
+		_, file, line, _ := runtime.Caller(1)
+		return internal.NewServiceInternalError(src, file, line, "Credential_FailedPassword", "Failed to generate a hashed password", map[string]interface{}{
+			"IdentityID":  i,
+			"Identifiers": identifiers,
+		})
+	}
+	errFailedCompare = func(src error, i uuid.UUID) error {
+		_, file, line, _ := runtime.Caller(1)
+		return internal.NewServiceInternalError(src, file, line, "Credential_FailedPassword", "Failed to compare password and hash", map[string]interface{}{
+			"IdentityID": i,
+		})
+	}
+	errFailedDecodePassword = func(src error, i uuid.UUID) error {
+		_, file, line, _ := runtime.Caller(1)
+		return internal.NewServiceInternalError(src, file, line, "Credential_FailedPassword", "Failed to decode password credentials", map[string]interface{}{
+			"IdentityID": i,
+		})
+	}
+	errFailedEncodePassword = func(src error, i uuid.UUID, ids []credential.Identifier) error {
+		_, file, line, _ := runtime.Caller(1)
+		return internal.NewServiceInternalError(src, file, line, "Credential_FailedPassword", "Failed to JSON encode hashed password", map[string]interface{}{
+			"IdentityID":  i,
+			"Identifiers": ids,
+		})
+
+	}
 )
 
 type service struct {
@@ -39,39 +72,28 @@ func (s *service) CreatePassword(uid uuid.UUID, password string, identifiers []c
 	// Test password strength
 	passStrength := zxcvbn.PasswordStrength(password, ids)
 	if passStrength.Score <= cfg.Credential.MinimumScore {
-		return nil, internal.NewServiceClientError(nil, "Credential_WeakPassword", "Password provided is too weak", map[string]interface{}{
-			"IdentityID":  uid,
-			"Identifiers": identifiers,
-		})
+		return nil, errWeakPassword(nil, uid, identifiers)
 	}
-	// 3. Hash password
+	// Hash password
 	newPass, err := generateFromPassword(password)
 	if err != nil {
-		_, file, line, _ := runtime.Caller(1)
-		return nil, internal.NewServiceInternalError(err, file, line, "Credential_FailedPassword", "Failed to generate a hashed password", map[string]interface{}{
-			"IdentityID":  uid,
-			"Identifiers": identifiers,
-		})
+		return nil, errFailedGeneratePassword(err, uid, identifiers)
 	}
 	credPass := credential.CredentialPassword{
 		HashedPassword: newPass,
 	}
 	jsonPass, err := json.Marshal(credPass)
 	if err != nil {
-		_, file, line, _ := runtime.Caller(1)
-		return nil, internal.NewServiceInternalError(err, file, line, "Credential_FailedPassword", "Failed to JSON encode hashed password", map[string]interface{}{
-			"IdentityID":  uid,
-			"Identifiers": identifiers,
-		})
+		return nil, errFailedEncodePassword(err, uid, identifiers)
 	}
-	// 4. Build Credential
+	// Build Credential
 	newCredential := credential.Credential{
 		Type:        credential.Password,
 		IdentityID:  uid,
 		Identifiers: identifiers,
 		Values:      string(jsonPass[:]),
 	}
-	// 5. Create Credential in repository
+	// Create Credential in repository
 	ncp, err := s.cr.Create(newCredential)
 	if err != nil {
 		return nil, internal.NewServiceClientError(err, "Credential_FailedCreate", "Invalid identifier(s)/password provided", map[string]interface{}{
@@ -89,20 +111,85 @@ func (s *service) ComparePassword(uid uuid.UUID, password string) error {
 	}
 	var hashed credential.CredentialPassword
 	if err := json.Unmarshal([]byte(cred.Values), &hashed); err != nil {
-		_, file, line, _ := runtime.Caller(1)
-		return internal.NewServiceInternalError(err, file, line, "Credential_FailedPassword", "Failed to decode password credentials", map[string]interface{}{
-			"IdentityID": uid,
-		})
+		return errFailedDecodePassword(err, uid)
 	}
 	match, err := comparePasswordAndHash(password, hashed.HashedPassword)
 	if err != nil {
-		_, file, line, _ := runtime.Caller(1)
-		return internal.NewServiceInternalError(err, file, line, "Credential_FailedPassword", "Failed to compare password and hash", map[string]interface{}{
-			"IdentityID": uid,
-		})
+		return errFailedCompare(err, uid)
 	}
 	if !match {
 		return errFailedFind(err, uid)
 	}
 	return nil
+}
+
+func (s *service) FindPasswordWithIdentifier(identifier string) (*credential.Credential, error) {
+	credential, err := s.cr.GetWithIdentifier(credential.Password, identifier)
+	if err != nil {
+		return nil, internal.NewServiceClientError(err, "Credential_FailedFind", "Invalid identifier provided", map[string]interface{}{
+			"Identifier": identifier,
+		})
+	}
+	return credential, nil
+}
+
+func (s *service) UpdatePassword(uid uuid.UUID, newPassword string) (*credential.Credential, error) {
+	// Find existing credential
+	cred, err := s.cr.GetWithIdentityID(credential.Password, uid)
+	if err != nil {
+		return nil, internal.NewServiceClientError(err, "Credential_FailedFind", "The account doesn't exist or the account doesn't have a password credential setup", map[string]interface{}{
+			"IdentityID": uid,
+		})
+	}
+	cfg := config.Get()
+	// Get identifiers to test password strength
+	ids := []string{}
+	for _, id := range cred.Identifiers {
+		ids = append(ids, id.Value)
+	}
+	// Test password strength
+	passStrength := zxcvbn.PasswordStrength(newPassword, ids)
+	if passStrength.Score <= cfg.Credential.MinimumScore {
+		return nil, errWeakPassword(nil, uid, cred.Identifiers)
+	}
+	// Compare new and old password
+	var hashed credential.CredentialPassword
+	if err := json.Unmarshal([]byte(cred.Values), &hashed); err != nil {
+		return nil, errFailedDecodePassword(err, uid)
+	}
+	match, err := comparePasswordAndHash(newPassword, hashed.HashedPassword)
+	if err != nil {
+		return nil, errFailedCompare(err, uid)
+	}
+	if match {
+		return nil, internal.NewServiceClientError(nil, "Credential_FailedUpdate", "Invalid password provided", map[string]interface{}{
+			"IdentityID":  uid,
+			"NewPassword": newPassword,
+		})
+	}
+	// Create new password
+	newPass, err := generateFromPassword(newPassword)
+	if err != nil {
+		return nil, errFailedGeneratePassword(err, uid, cred.Identifiers)
+	}
+	credPass := credential.CredentialPassword{
+		HashedPassword: newPass,
+	}
+	jsonPass, err := json.Marshal(credPass)
+	if err != nil {
+		return nil, errFailedEncodePassword(err, uid, cred.Identifiers)
+	}
+	// Build Credential
+	uc := *cred
+	uc.Values = string(jsonPass[:])
+	// Update password
+	updated, err := s.cr.Update(uc)
+	if err != nil {
+		_, file, line, _ := runtime.Caller(1)
+		return nil, internal.NewServiceInternalError(err, file, line, "Credential_FailedUpdate", "Failed to update credential", map[string]interface{}{
+			"IdentityID":        uid,
+			"UpdatedCredential": uc,
+		})
+	}
+	return updated, nil
 }

--- a/user/identity/service/service.go
+++ b/user/identity/service/service.go
@@ -10,15 +10,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var (
-	errInvalidID = func(src error) error {
-		return internal.NewServiceClientError(src, "identity_id_invalid", "Invalid id provided", nil)
-	}
-	errInvalidUsername = func(src error) error {
-		return internal.NewServiceClientError(src, "identity_username_invalid", "Invalid username provided. Username is either already taken or contains invalid characters", nil)
-	}
-)
-
 type service struct {
 	ir identity.Repository
 }


### PR DESCRIPTION
Adds recovery flow that does the following after initialized:

1. Require user to input an `Identifier` that belongs to a `Password` `Credential`
2. If an invalid `Identifier` was provided then invalidate `Flow` by updating `Status: Fail`. Otherwise, send activation link to Email `Contacts` that have been `Verified` and have a `Type: Backup`
3. When the user clicks on the activation link then require new `Password` `Credential` to be inputted
4. After new `Password` `Credential` has been set then complete the flow

closes #1 